### PR TITLE
Update Go and Dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,15 @@
 module github.com/breml/dlo
 
-go 1.19
+go 1.24.0
+
+toolchain go1.24.7
 
 require (
 	github.com/TreyBastian/colourize v0.0.0-20220718091059-2c32423e75f7
 	github.com/olekukonko/tablewriter v0.0.5
 )
 
-require github.com/mattn/go-runewidth v0.0.9 // indirect
+require (
+	github.com/clipperhouse/uax29/v2 v2.2.0 // indirect
+	github.com/mattn/go-runewidth v0.0.19 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,9 @@
 github.com/TreyBastian/colourize v0.0.0-20220718091059-2c32423e75f7 h1:N319PyiAeatcNBruXex1wOW81W+86Ouz+6ZJqU5yMNM=
 github.com/TreyBastian/colourize v0.0.0-20220718091059-2c32423e75f7/go.mod h1:qYZagpzkOxOtrbx2AfOO90niGMZ2RImNJ47J2942+No=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/clipperhouse/uax29/v2 v2.2.0 h1:ChwIKnQN3kcZteTXMgb1wztSgaU+ZemkgWdohwgs8tY=
+github.com/clipperhouse/uax29/v2 v2.2.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
+github.com/mattn/go-runewidth v0.0.19/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=


### PR DESCRIPTION
- Update Go from 1.19 to 1.24.0 (toolchain go1.24.7)
- Update github.com/mattn/go-runewidth from v0.0.9 to v0.0.19
- Add new indirect dependency github.com/clipperhouse/uax29/v2 v2.2.0
- Keep github.com/olekukonko/tablewriter at v0.0.5 for API compatibility
- All tests pass and build succeeds

This brings the project up to date with the latest Go version while maintaining compatibility with existing code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)